### PR TITLE
First DUB support with hard-coded dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ script:
   - ./test.sh dlangtour/core-exec:${DLANG_VERSION}
 
 after_success:
-  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - docker push dlangtour/core-exec:${DLANG_VERSION}
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" ; fi
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then docker push dlangtour/core-exec:${DLANG_VERSION} ; fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,10 @@ cd /sandbox
 echo "$1" | base64 -d > onlineapp.d
 
 args=${DOCKER_FLAGS:-""}
-if [ -z ${2:-""} ] ; then
-    exec timeout -s KILL ${TIMEOUT:-20} ${DLANG_EXEC} -run $args onlineapp.d | tail -n100
+if  grep -qE "dub[.](sdl|json):" onlineapp.d > /dev/null 2>&1  ; then
+    exec timeout -s KILL ${TIMEOUT:-20} dub -q --compiler=${DLANG_EXEC} --single --skip-registry=all onlineapp.d | tail -n100
+elif [ -z ${2:-""} ] ; then
+    exec timeout -s KILL ${TIMEOUT:-20} ${DLANG_EXEC} $args -run onlineapp.d | tail -n100
 else
-    exec timeout -s KILL ${TIMEOUT:-20} bash -c "echo $2 | base64 -d | ${DLANG_EXEC} -run $args onlineapp.d | tail -n100"
+    exec timeout -s KILL ${TIMEOUT:-20} bash -c "echo $2 | base64 -d | ${DLANG_EXEC} $args -run onlineapp.d | tail -n100"
 fi

--- a/test.sh
+++ b/test.sh
@@ -29,3 +29,12 @@ bsource=$(echo $source | base64 -w0)
 [ "$(DOCKER_FLAGS="-version=Fooo" docker run -e DOCKER_FLAGS --rm $dockerId $bsource)" == "" ]
 [ "$(DOCKER_FLAGS="-version=Foo" docker run -e DOCKER_FLAGS --rm $dockerId $bsource)" != "Hello world" ]
 [ "$(DOCKER_FLAGS="-version=Bar -version=Foo" docker run -e DOCKER_FLAGS --rm $dockerId $bsource)" != "Hello world" ]
+
+## dub file
+source='/++dub.sdl: name"foo"+/ void main() { import std.stdio; writeln("Hello World"); }'
+bsource=$(echo "$source" | base64 -w0)
+[ "$(docker run --rm $dockerId $bsource)" == "Hello World" ]
+
+source="/++dub.sdl: name\"foo\" \n dependency\"mir\" version=\"1.1.1\"+/ void main() { import mir.combinatorics, std.stdio; writeln([0, 1].permutations); }"
+bsource=$(echo -e "$source" | base64 -w0)
+[ "$(docker run --rm "$dockerId" "$bsource")" == "[[0, 1], [1, 0]]" ]


### PR DESCRIPTION
The nice thing about this is that this almost works out of the box and because of the DUB single file format, we don't even need to modify anything on the tour.

![image](https://user-images.githubusercontent.com/4370550/28445026-cf8a3314-6dc1-11e7-9f25-7278ea221425.png)


This is just a first step to experiment with DUB support.
@ZombineDev suggested to use a docker volume as cache and thus allow execution of arbitrary DUB packages.

Next steps:
- "Add library" button (like [JSBin](http://jsbin.com/?html,js,output))
- Fix syntax highlighting (`/++` isn't detected)