### PR TITLE
Emulate a terminal when DOCKER_COLOR is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ command line parameter:
     $ DOCKER_FLAGS="-version=Foo" docker run -e DOCKER_FLAGS --rm dlangtour/core-exec:dmd $bsource
     Hello World
 
+### Colored output
+
+    $ bsource=$(echo 'void main() { import foo; version(Foo) writeln("Hello World"); }' | base64 -w0)
+    $ DOCKER_COLOR="on" docker run -e DOCKER_COLOR --rm dlangtour/core-exec:dmd $bsource
+
+![image](https://user-images.githubusercontent.com/4370550/28495813-0f497240-6f5b-11e7-9108-18e5ad6366c5.png)
+
 ## Docker image
 
 The docker image gets built after every push to `master` and pushed to [DockerHub](https://hub.docker.com/r/dlang-tour/core-exec/).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,10 +8,16 @@ cd /sandbox
 echo "$1" | base64 -d > onlineapp.d
 
 args=${DOCKER_FLAGS:-""}
+coloring=${DOCKER_COLOR:-"off"}
+export TERM="dtour"
+
 if  grep -qE "dub[.](sdl|json):" onlineapp.d > /dev/null 2>&1  ; then
     exec timeout -s KILL ${TIMEOUT:-20} dub -q --compiler=${DLANG_EXEC} --single --skip-registry=all onlineapp.d | tail -n100
 elif [ -z ${2:-""} ] ; then
-    exec timeout -s KILL ${TIMEOUT:-20} ${DLANG_EXEC} $args -run onlineapp.d | tail -n100
+    exec timeout -s KILL ${TIMEOUT:-20} \
+        bash -c 'faketty () { script -qfc "$(printf "%q " "$@")" /dev/null ; };'"faketty ${DLANG_EXEC} $args -color=$coloring -run onlineapp.d | cat" \
+        | sed 's/\r//' \
+        | tail -n100
 else
     exec timeout -s KILL ${TIMEOUT:-20} bash -c "echo $2 | base64 -d | ${DLANG_EXEC} $args -run onlineapp.d | tail -n100"
 fi


### PR DESCRIPTION
Allows to return ANSI colors for the default path. `stdin` and `DUB` seem to be more complicated, so leaving them plain, old colorless for now.

Note that `DOCKER_COLOR` needs to explicitly set to `on`.