### PR TITLE
Fix failing cron builds to dlang.org's HTTPS by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y libc-dev gcc cu
 ENV DLANG_VERSION "dmd-nightly"
 ENV DLANG_EXEC "dmd"
 
-RUN curl -fsS -o /tmp/install.sh http://dlang.org/install.sh \
+RUN curl -fsS -o /tmp/install.sh https://dlang.org/install.sh \
  && bash /tmp/install.sh -p /dlang install -s ${DLANG_VERSION} \
  && rm -f /dlang/d-keyring.gpg \
  && rm -rf /dlang/dub* \


### PR DESCRIPTION
Currently dmd still uses 2.075 due to the failing Travis Cron. This should fix Travis and thus update the Docker images.
I don't know why we didn't receive a notification for the failing cron.