### PR TITLE
update list of mir packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,13 +60,16 @@ RUN mkdir /sandbox && chown d-user:nogroup /sandbox
 USER d-user
 
 RUN cd /sandbox && for package_name in \
-		mir-algorithm \
-		mir-random \
-		mir-core \
-		mir-runtime \
-		mir-optim \
-		mir \
 		asdf \
+		mir-algorithm \
+		mir-blas \
+		mir-core \
+		mir-cpuid \
+		mir-integral \
+		mir-lapack \
+		mir-optim \
+		mir-random \
+		mir \
 		stdx-allocator \
 		lubeck \
 		numir \
@@ -80,8 +83,6 @@ RUN cd /sandbox && for package_name in \
 		pegged \
 		sumtype \
 		optional \
-		mir-lapack \
-		mir-blas \
 		; do \
       	package="$(echo $package_name | cut -d: -f1)"; \
       	version="$(echo $package_name | grep : |cut -d: -f2)"; \


### PR DESCRIPTION
Add all packages from `Mir Libraries` menu at http://mir-integral.libmir.org/mir_quadrature.html and friends. Packages order is preserved like in the `*.libmir.org`.