### PR TITLE
ci(gh-actions): Fix incorrect use of `build-push-action`

### DIFF
--- a/.github/workflows/run-test-sh.yml
+++ b/.github/workflows/run-test-sh.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: ${{ github.event_name == 'push' }}
-          load: true
+          load: ${{ github.event_name != 'push' }}
           tags: dlangtour/core-exec:${{ matrix.version }}
           build-args: |
             DLANG_VERSION=${{ matrix.version }}


### PR DESCRIPTION
The `push` and `load` options are mutually exclusive