### PR TITLE
Github-Action: Restrict push trigger to master

### DIFF
--- a/.github/workflows/run-test-sh.yml
+++ b/.github/workflows/run-test-sh.yml
@@ -1,6 +1,11 @@
 name: run-test-shell
 
-on: [ pull_request, push ]
+on:
+  pull_request:
+
+  push:
+    branches:
+      - master
 
 jobs:
   main:


### PR DESCRIPTION
Avoid duplicated jobs for PR's from local branches