### PR TITLE
Github Actions: Disable scheduled build for forks

### DIFF
--- a/.github/workflows/run-test-sh.yml
+++ b/.github/workflows/run-test-sh.yml
@@ -12,6 +12,10 @@ on:
 jobs:
   main:
     name: Test image
+
+    # Only run schedule for the main repository - not forks
+    if: ${{ github.event_name != 'schedule' || github.repository == 'dlang-tour/core-exec' }}
+
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Scheduled builds don't need to be run for forks and will fail anyways due to missing credentials.